### PR TITLE
Locations clickable for availability and appointment

### DIFF
--- a/Infrastructure/ViewModels/AppointmentViewModel.cs
+++ b/Infrastructure/ViewModels/AppointmentViewModel.cs
@@ -15,5 +15,6 @@ namespace Infrastructure.ViewModels
         public string Comments { get; set; }
 
         public bool IsScheduled { get; set; }
+        public string Campus { get; set; }
     }
 }

--- a/SteamboatWillieWeb/Pages/Appointments/Index.cshtml.cs
+++ b/SteamboatWillieWeb/Pages/Appointments/Index.cshtml.cs
@@ -225,7 +225,8 @@ namespace SteamboatWillieWeb.Pages.Appointments
                 Time = availability.StartTime.ToShortTimeString(),
                 Location = _unitOfWork.Location.GetById(availability.LocationId).LocationValue,
                 ProviderType = provider.Title,
-                ProviderName = _unitOfWork.AppUser.GetById(provider.AppUserId).FullName
+                ProviderName = _unitOfWork.AppUser.GetById(provider.AppUserId).FullName,
+                Campus = _unitOfWork.Location.GetById(availability.LocationId).Campus
             };
             return Partial("./_RegisterAppointmentPartial", this);
         }

--- a/SteamboatWillieWeb/Pages/Appointments/_DetailsAppointmentPartial.cshtml
+++ b/SteamboatWillieWeb/Pages/Appointments/_DetailsAppointmentPartial.cshtml
@@ -14,6 +14,7 @@
                 <div class="col-md-3 text-end">
                     <span class="d-inline-block"><strong>When: </strong> </span> <br />
                     <span class="d-inline-block"><strong>With: </strong> </span> <br />
+                    <span class="d-inline-block"><strong>Campus: </strong> </span> <br />
                     <span class="d-inline-block"><strong>Location: </strong> </span> <br />
                     <span class="d-inline-block"><strong>Comments: </strong></span>
                 </div>
@@ -21,7 +22,22 @@
                     <!-- Info about appointments-->
                     <span>@Model.AppointmentModelInput.Date @Model.AppointmentModelInput.Time </span> <br />
                     <span>@Model.AppointmentModelInput.ProviderName </span> <br />
-                    <span>@Model.AppointmentModelInput.Location </span> <br />
+                    <span>@Model.AppointmentModelInput.Campus</span> <br />
+                    @if (Model.AppointmentModelInput.Campus == "Online")
+                    {
+                        @if (Model.AppointmentModelInput.Location.Contains("http"))
+                        {
+                            <a href="@Model.AppointmentModelInput.Location" target="_blank">@Model.AppointmentModelInput.Location</a>
+                        }
+                        else
+                        {
+                            <a href="http://@Model.AppointmentModelInput.Location" target="_blank">@Model.AppointmentModelInput.Location</a>
+                        }
+                    }
+                    else
+                    {
+                        <span>@Model.AppointmentModelInput.Location</span> <br />
+                    }
                     <div id="notEdit">
                         <span>@Model.AppointmentModelInput.Comments </span>
                     </div>

--- a/SteamboatWillieWeb/Pages/Appointments/_RegisterAppointmentPartial.cshtml
+++ b/SteamboatWillieWeb/Pages/Appointments/_RegisterAppointmentPartial.cshtml
@@ -13,12 +13,14 @@
                 <div class="col-md-3 text-end">
                     <span class="d-inline-block"><strong>When: </strong> </span> <br />
                     <span class="d-inline-block"><strong>With: </strong> </span> <br />
+                    <span class="d-inline-block"><strong>Campus: </strong> </span> <br />
                     <span class="d-inline-block"><strong>Location: </strong> </span> <br />
                     <span class="d-inline-block"><strong>Comments: </strong></span>
                 </div>
                 <div class="col-md-9">
                     <span>@Model.InputModel.Date @Model.InputModel.Time</span> <br />
                     <span>@Model.InputModel.ProviderName</span> <br />
+                    <span>@Model.InputModel.Campus</span> <br />
                     <span>@Model.InputModel.Location</span> <br />
                     <textarea cols="3" style="width: 95%" asp-for="InputModel.Comments"></textarea>
                 </div>

--- a/SteamboatWillieWeb/Pages/Availability/_ViewAvailabilityPartial.cshtml
+++ b/SteamboatWillieWeb/Pages/Availability/_ViewAvailabilityPartial.cshtml
@@ -44,7 +44,23 @@
                         <span>@Model.AvailabilityModelInput.ClientEmail</span> <br />
                     }
                     <span>@Model.AvailabilityModelInput.Campus</span> <br />
-                    <span>@Model.AvailabilityModelInput.Location</span> <br />
+                    @if (Model.AvailabilityModelInput.Campus == "Online")
+                    {
+                        @if (Model.AvailabilityModelInput.Location.Contains("http"))
+                        {
+                            <a href="@Model.AvailabilityModelInput.Location" target="_blank">@Model.AvailabilityModelInput.Location</a>
+                        }
+                        else
+                        {
+                            <a href="http://@Model.AvailabilityModelInput.Location" target="_blank">@Model.AvailabilityModelInput.Location</a>
+                        }
+                    }
+                    else
+                    {
+                        <span>@Model.AvailabilityModelInput.Location</span> <br />
+                    }
+                    
+                   @*  <span>@Model.AvailabilityModelInput.Location</span> <br /> *@
                     @if (Model.AvailabilityModelInput.IsAppointment)
                     {
                         <span>@Model.AvailabilityModelInput.Comments</span> <br />

--- a/SteamboatWillieWeb/Pages/Index.cshtml
+++ b/SteamboatWillieWeb/Pages/Index.cshtml
@@ -146,7 +146,7 @@ else
                                     <strong>When:</strong>
                                     @app.Date <br />
                                     <pre>       @app.StartTime - @app.EndTime</pre>
-                                    <strong>Where:</strong> @if ((app.Location.Contains("www") || app.Location.Contains("http") || app.Location.Contains(".com") || app.Location.Contains(".edu") || app.Location.Contains(".org") || app.Location.Contains(".gov") || app.Location.Contains(".gg") || app.Location.Contains(".net") || app.Location.Contains(".us") || app.Location.Contains("zoom.")))
+                                    <strong>Where:</strong> @if (app.Campus == "Online")
                                     {
                                         @if (app.Location.Contains("http"))
                                         {

--- a/SteamboatWillieWeb/Pages/Index.cshtml.cs
+++ b/SteamboatWillieWeb/Pages/Index.cshtml.cs
@@ -78,7 +78,7 @@ namespace SteamboatWillieWeb.Pages
                             StartTime = app.ProviderAvailability.StartTime.ToShortTimeString(),
                             EndTime = app.ProviderAvailability.EndTime.ToShortTimeString(),
                             Location = _unitOfWork.Location.GetById(app.ProviderAvailability.LocationId).LocationValue,
-                            Campus = _unitOfWork.Location.GetById(app.ProviderAvailability.LocationId).LocationValue
+                            Campus = _unitOfWork.Location.GetById(app.ProviderAvailability.LocationId).Campus
                         });
                         var x = Appointments.Last();
                         x.Color = GetColor(x.AppointmentType);
@@ -240,7 +240,8 @@ namespace SteamboatWillieWeb.Pages
                 ProviderType = provider.Title,
                 ProviderName = _unitOfWork.AppUser.GetById(provider.AppUserId).FullName,
                 Comments = appointment.StudentComments,
-                IsScheduled = appointment.ProviderAvailability.Scheduled
+                IsScheduled = appointment.ProviderAvailability.Scheduled,
+                Campus = _unitOfWork.Location.GetById(appointment.ProviderAvailability.LocationId).Campus
             };
             return Partial("./Appointments/_DetailsAppointmentPartial", this);
         }


### PR DESCRIPTION
I think I covered all the bases. Online campus locations now show up as a link. If they aren't online, it will just show up as plain text. Changes affect the popups on index for both clients and provider when clicking on appointments (also affects popups for availability for provider). Also added campus to the popups that didn't have it. Links are not clickable on registering for an appointment, Links are only clickable for clients after they've registered for the appointment.